### PR TITLE
KVM: cleanup startTime_ related code

### DIFF
--- a/src/kvmdriver.cpp
+++ b/src/kvmdriver.cpp
@@ -125,8 +125,7 @@ KvmDriver::KvmDriver( const std::string &domain, bool useVE )
 
 	startTime_ = kvmi_get_starttime( domCtx_ );
 
-	logger << TRACE << "kvmi_get_starttime() => " << static_cast<int64_t>( startTime_ ) << " ms "
-	       << static_cast<uint32_t>( startTime_ / 1000 ) << " secs" << std::flush;
+	logger << TRACE << "kvmi_get_starttime() => " << startTime_ << " secs" << std::flush;
 
 	if ( useVE ) {
 		kvmi_eptp_support( domCtx_, &eptpSupported_ );
@@ -1254,11 +1253,6 @@ bool KvmDriver::flushMSREvents( unsigned short vcpu, const std::set<unsigned int
 
 uint32_t KvmDriver::startTime()
 {
-	if ( !startTime_ )
-		return static_cast<uint32_t>( -1 );
-
-	int64_t secs = startTime_ / 1000; // from milliseconds
-
 	return static_cast<uint32_t>( secs );
 }
 

--- a/src/kvmdriver.h
+++ b/src/kvmdriver.h
@@ -325,7 +325,7 @@ private:
 	int                               flags_{ KVMI_REP_OPTIMIZATIONS_FLAG };
 	void *                            domCtx_;
 	std::string                       domain_;
-	int64_t                           startTime_;
+	int64_t                           startTime_{ -1 };
 	mutable RegsCache                 regsCache_;
 	PageCache                         pageCache_;
 	bool                              suspending_{ false };


### PR DESCRIPTION
`kvmi_get_starttime()` returns the time in seconds.